### PR TITLE
fix the ini mode test

### DIFF
--- a/autorevision
+++ b/autorevision
@@ -598,7 +598,7 @@ if [[ ! -z "${AFILETYPE}" ]]; then
 		luaOutput
 	elif [[ "${AFILETYPE}" = "php" ]]; then
 		phpOutput
-	elif [ "${AFILETYPE}" = "ini" ]]; then
+	elif [[ "${AFILETYPE}" = "ini" ]]; then
 		iniOutput
 	elif [[ "${AFILETYPE}" = "js" ]]; then
 		jsOutput


### PR DESCRIPTION
commit 5e3c1c49e21030e16e7e8ba6d6d7c6334efe3066 overlooked one of the tests and caused bash to output:

```
./autorevision: line 601: [: missing `]'
```
