### PR TITLE
Fix up the manpage to work around a couple asciidoctor/github mishandlings

### DIFF
--- a/autorevision.asciidoc
+++ b/autorevision.asciidoc
@@ -1,5 +1,4 @@
 = AUTOREVISION(1) =
-:doctype: manpage
 
 == NAME ==
 autorevision - extract current-revision metadata from version-control repositories


### PR DESCRIPTION
The software used on GitHub's side does not support AsciiDoc fully enough to render this properly, but the fixes to work around this should not be too much of a hassle.
