### PR TITLE
Fix typo. (loacl -> local)

### DIFF
--- a/autorevision.sh
+++ b/autorevision.sh
@@ -317,7 +317,7 @@ svnRepo() {
 	case "${PWD}" in
 	/*trunk*|/*branches*|/*tags*)
 		local lastbase=""
-		loacl fn="${PWD}"
+		local fn="${PWD}"
 		while :
 		do
 			base="$(basename "${fn}")"


### PR DESCRIPTION
It caused an error `loacl: command not found` on svn repository.