### PR TITLE
Fixing empty VCS_WS_MODIFIED variable for SVN

### DIFF
--- a/autorevision.sh
+++ b/autorevision.sh
@@ -301,6 +301,8 @@ svnRepo() {
 				else
 					VCS_WC_MODIFIED="1"
 				fi
+			else
+			    VCS_WC_MODIFIED="0"
 			fi
 		;;
 	esac


### PR DESCRIPTION
This was leading to compile time errors in the generated code.