### PR TITLE
Make it work on Windows machines

### DIFF
--- a/autorevision.sh
+++ b/autorevision.sh
@@ -1029,7 +1029,7 @@ pathSegment() {
 	local depth="0"
 
 	if [ ! -z "${pathz}" ]; then
-		while [ ! "${pathz}" = "/" ] && [ ! "${pathz}" = "." ] && [ ! "${pathz}" = "C:" ]; do
+		while [ ! "${pathz}" = "/" ] && [ ! "${pathz}" = "." ] && [ ! "${pathz}" = "$(echo "${pathz}" | sed -e 's:/::')" ]; do
 			pathz="$(dirname "${pathz}")"
 			depth="$((depth+1))"
 		done

--- a/autorevision.sh
+++ b/autorevision.sh
@@ -1029,7 +1029,7 @@ pathSegment() {
 	local depth="0"
 
 	if [ ! -z "${pathz}" ]; then
-		while [ ! "${pathz}" = "/" ] && [ ! "${pathz}" = "." ]; do
+		while [ ! "${pathz}" = "/" ] && [ ! "${pathz}" = "." ] && [ ! "${pathz}" = "C:" ]; do
 			pathz="$(dirname "${pathz}")"
 			depth="$((depth+1))"
 		done


### PR DESCRIPTION
When running the script on Windows machine it permanently hangs in pathSegment function.  The reason is because that function walks up to '/' or '.' path.   On windows machines the top of the path is usually  C:\.   

This patch fixes the problem

