### PR TITLE
Add an output-file option

### DIFF
--- a/autorevision.asciidoc
+++ b/autorevision.asciidoc
@@ -211,6 +211,9 @@ be used in the same invocation.
 *-o* '<cache-file>'::
 Sets the name of the cache file.
 
+*-O* '<output-file>'::
+Sets the name of a file to write output to, instead of using stdout.
+
 *-f*::
 Forces the use of cache data even when in a repo; useful for speeding
 up subsequent runs if more than one output format is needed.

--- a/autorevision.sh
+++ b/autorevision.sh
@@ -10,11 +10,14 @@
 # Usage message.
 arUsage() {
 	cat > "/dev/stderr" << EOF
-usage: autorevision {-t output-type | -s symbol} [-o cache-file [-f] ] [-V]
+usage: autorevision {-t output-type | -s symbol} \\
+			[-o cache-file [-f] ] [-O output-file ] [-V]
+
 	Options include:
 	-t output-type		= specify output type
 	-s symbol		= specify symbol output
 	-o cache-file		= specify cache file location
+	-O output-file		= specify output file, instead of stdout
 	-f			= force the use of cache data
 	-U			= check for untracked files in svn
 	-V			= emit version and exit
@@ -66,13 +69,16 @@ EOF
 # Config
 ARVERSION="&&ARVERSION&&"
 TARGETFILE="/dev/stdout"
-while getopts ":t:o:s:VfU" OPTION; do
+while getopts ":t:o:O:s:VfU" OPTION; do
 	case "${OPTION}" in
 		t)
 			AFILETYPE="${OPTARG}"
 		;;
 		o)
 			CACHEFILE="${OPTARG}"
+		;;
+		O)
+			TARGETFILE="${OPTARG}"
 		;;
 		f)
 			CACHEFORCE="1"


### PR DESCRIPTION
This may be used instead of basic shell redirection, particularly on
(broken) systems where that might not work.
