### PR TITLE
Set VCS_BASENAME from main working tree if using git-worktree

### DIFF
--- a/autorevision.asciidoc
+++ b/autorevision.asciidoc
@@ -136,7 +136,9 @@ The repository type - "git", "hg", "bzr", or "svn".
 The basename of the directory root.  For most VCSes this will simply
 be the basename of the repository root directory.  For Subversion,
 *autorevision* will attempt to navigate up though trunk, branches, and
-tags directories to find the actual root.
+tags directories to find the actual root. For git when in a linked working
+tree created by *git-worktree(1)*, *autorevision* will attempt to use the main
+working tree's basename.
 
 *VCS_NUM*::
 A count of revisions between the current one and the initial

--- a/autorevision.sh
+++ b/autorevision.sh
@@ -147,7 +147,23 @@ gitRepo() {
 
 	VCS_TYPE="git"
 
-	VCS_BASENAME="$(basename "${PWD}")"
+	# Portably canonicalize the path to the git dir.
+	${LOCAL} gitDir="$(cd "$(git rev-parse --git-path objects/.. 2>/dev/null)"; echo "${PWD}")"
+
+	# Use the basename from the main working tree.
+	case "$(cd "${gitDir}" && git rev-parse --is-bare-repository 2>/dev/null)" in
+		true)
+			# Strip .git suffix if present.
+			VCS_BASENAME="$(basename "${gitDir}" .git)"
+			;;
+		false)
+			VCS_BASENAME="$(basename "$(dirname "${gitDir}")")"
+			;;
+		*)
+			echo "error: Cannot determine if repository is bare." 1>&2
+			exit 1
+			;;
+	esac
 
 	${LOCAL} currentRev="$(git rev-parse HEAD)"
 


### PR DESCRIPTION
The prior behavior picked up the basename of the worktree, which is
unlikely to be what the user intended.

fixes #38

### Preflight Checklist
I have:

 - [x] Read the Contributor's Guidelines.
 - [x] Updated the examples as necessary.
 - [x] Updated the documentation as necessary.
 - [ ] GPG signed my commits.
