### PR TITLE
test.sh: fix "mktemp: too few X's in template ‘autorevision’"

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,7 +14,7 @@ testPath="$(cd "$(dirname "$0")"; pwd -P)"
 vers="$(./autorevision -fo ./autorevision.cache -s VCS_TAG | sed -e 's:v/::')"
 tdir="autorevision-${vers}"
 tarball="${tdir}.tgz"
-tmpdir="$(mktemp -dqt autorevision)"
+tmpdir="$(mktemp -dqt autorevisionXXX)"
 
 
 # Copy the tarball to a temp directory


### PR DESCRIPTION
My GNU coreutils mktemp v8.28 complains about missing X's. Fix it.

### Preflight Checklist
I have:

 - [x] Read the Contributor's Guidelines.
 - [ ] Updated the examples as necessary. (Not applicable.)
 - [ ] Updated the documentation as necessary.  (Not applicable.)
 - [ ] GPG signed my commits.
