### PR TITLE
Change root path detection to allow busybox-w32 roots

### DIFF
--- a/autorevision.sh
+++ b/autorevision.sh
@@ -1234,8 +1234,10 @@ pathSegment() {
 	${LOCAL} depth="0"
 
 	if [ ! -z "${pathz}" ]; then
+		${LOCAL} last_pathz=""
 		# Continue until we are at / or there are no path separators left.
-		while [ ! "${pathz}" = "/" ] && [ ! "${pathz}" = "$(echo "${pathz}" | sed -e 's:/::')" ]; do
+		while [ ! "${pathz}" = "${last_pathz}" ] && [ ! "${pathz}" = "$(echo "${pathz}" | sed -e 's:/::')" ]; do
+			last_pathz="${pathz}"
 			pathz="$(dirname "${pathz}")"
 			depth="$((depth+1))"
 		done


### PR DESCRIPTION
### Preflight Checklist
I have:

 - [X] Read the Contributor's Guidelines.
 - [X] Updated the examples as necessary.
 - [X] Updated the documentation as necessary.
 - [ ] GPG signed my commits.

I have to build code on Windows. One of the ways I can ensure a sane command-line environment for build scripts is to use the Windows port of busybox (busybox-w32), as I can then just bundle the single executable in my source repo.

The one hurdle stopping me using autorevision with this use-case is that busybox-w32 has a filesystem root for each drive, (such as C:/ or D:/). This means that the loop in the pathSegment function won't terminate, because $pathz never equals '/' - it'll be C:/ or D:/.

To fix this, I added a test inside that loop to determine whether or not `dirname` has altered the path passed to it - `dirname /` = `/` when running under a Linux shell, and similarly `dirname C:/` = `C:/` when running under busybox-w32. I didn't want to replace the test for root (so as to cause minimum change).